### PR TITLE
EWEB-94 - 23984 - Geração do Bloco E Sped Fiscal

### DIFF
--- a/src/Elements/ICMSIPI/E116.php
+++ b/src/Elements/ICMSIPI/E116.php
@@ -14,8 +14,8 @@ class E116 extends Element implements ElementInterface
 
     protected $parameters = [
         'COD_OR' => [
-            'type'     => 'string',
-            'regex'    => '^[000|003|004|005|006|090]+$',
+            'type' => 'string',
+            'regex' => '^[000|001|002|003|004|005|006|090|999]+$',
             'required' => true,
             'info'     => 'Código da obrigação a recolher, conforme a Tabela 5.4',
             'format'   => ''

--- a/src/Elements/ICMSIPI/E116.php
+++ b/src/Elements/ICMSIPI/E116.php
@@ -100,9 +100,9 @@ class E116 extends Element implements ElementInterface
          * Campo 06 (NUM_PROC) Validação: se este campo estiver preenchido, os campos
          * IND_PROC e PROC também devem estar preenchidos.
          */
-        if (!empty($this->std->num_proc) && (empty($this->std->ind_proc) || empty($this->std->proc))) {
+        if (!empty($this->std->num_proc) && (($this->std->ind_proc != '0' && empty($this->std->ind_proc)) || empty($this->std->proc))) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se o campo NUM_PROC estiver preenchido, "
-                . "os campos IND_PROC e PROC também devem estar preenchidos." . $this->std->num_proc);
+                . "os campos IND_PROC e PROC também devem estar preenchidos.");
         }
     }
 }

--- a/src/Elements/ICMSIPI/E116.php
+++ b/src/Elements/ICMSIPI/E116.php
@@ -17,69 +17,69 @@ class E116 extends Element implements ElementInterface
             'type' => 'string',
             'regex' => '^[000|001|002|003|004|005|006|090|999]+$',
             'required' => true,
-            'info'     => 'Código da obrigação a recolher, conforme a Tabela 5.4',
-            'format'   => ''
+            'info' => 'Código da obrigação a recolher, conforme a Tabela 5.4',
+            'format' => ''
         ],
         'VL_OR' => [
-            'type'     => 'numeric',
-            'regex'    => '^\d+(\.\d*)?|\.\d+$',
+            'type' => 'numeric',
+            'regex' => '^\d+(\.\d*)?|\.\d+$',
             'required' => true,
-            'info'     => 'Valor da obrigação a recolher',
-            'format'   => '15v2'
+            'info' => 'Valor da obrigação a recolher',
+            'format' => '15v2'
         ],
         'DT_VCTO' => [
-            'type'     => 'numeric',
-            'regex'    => '^(0[1-9]|[1-2][0-9]|31(?!(?:0[2469]|11))|30(?!02))(0[1-9]|1[0-2])([12]\d{3})$',
+            'type' => 'numeric',
+            'regex' => '^(0[1-9]|[1-2][0-9]|31(?!(?:0[2469]|11))|30(?!02))(0[1-9]|1[0-2])([12]\d{3})$',
             'required' => true,
-            'info'     => 'Data de vencimento da obrigação',
-            'format'   => ''
+            'info' => 'Data de vencimento da obrigação',
+            'format' => ''
         ],
         'COD_REC' => [
-            'type'     => 'string',
-            'regex'    => '^.*$',
+            'type' => 'string',
+            'regex' => '^.*$',
             'required' => true,
-            'info'     => 'Código de receita referente à obrigação, próprio '
-            .'da unidade da federação, conforme legislação estadual.',
-            'format'   => ''
+            'info' => 'Código de receita referente à obrigação, próprio '
+                . 'da unidade da federação, conforme legislação estadual.',
+            'format' => ''
         ],
         'NUM_PROC' => [
-            'type'     => 'string',
-            'regex'    => '^.{1,15}$',
+            'type' => 'string',
+            'regex' => '^.{1,15}$',
             'required' => false,
-            'info'     => 'Número do processo ou auto de infração ao qual a obrigação está vinculada, se houver.',
-            'format'   => ''
+            'info' => 'Número do processo ou auto de infração ao qual a obrigação está vinculada, se houver.',
+            'format' => ''
         ],
         'IND_PROC' => [
-            'type'     => 'string',
-            'regex'    => '^[0|1|2|9]$',
+            'type' => 'string',
+            'regex' => '^[0|1|2|9]$',
             'required' => false,
-            'info'     => 'Indicador da origem do processo: '
-            .'0- SEFAZ;'
-            .'1- Justiça Federal;'
-            .'2- Justiça Estadual;'
-            .'9- Outros',
-            'format'   => ''
+            'info' => 'Indicador da origem do processo: '
+                . '0- SEFAZ;'
+                . '1- Justiça Federal;'
+                . '2- Justiça Estadual;'
+                . '9- Outros',
+            'format' => ''
         ],
         'PROC' => [
-            'type'     => 'string',
-            'regex'    => '^.*$',
+            'type' => 'string',
+            'regex' => '^.*$',
             'required' => false,
-            'info'     => 'Descrição resumida do processo que embasou o lançamento',
-            'format'   => ''
+            'info' => 'Descrição resumida do processo que embasou o lançamento',
+            'format' => ''
         ],
         'TXT_COMPL' => [
-            'type'     => 'string',
-            'regex'    => '^.*$',
+            'type' => 'string',
+            'regex' => '^.*$',
             'required' => false,
-            'info'     => 'Descrição complementar das obrigações a recolher.',
-            'format'   => ''
+            'info' => 'Descrição complementar das obrigações a recolher.',
+            'format' => ''
         ],
         'MES_REF' => [
-            'type'     => 'numeric',
-            'regex'    => '^((?!(13^))|30(?!02))(0[1-9]|1[0-2])([12]\d{3})$',
+            'type' => 'numeric',
+            'regex' => '^((?!(13^))|30(?!02))(0[1-9]|1[0-2])([12]\d{3})$',
             'required' => true,
-            'info'     => 'Informe o mês de referência no formato “mmaaaa”',
-            'format'   => ''
+            'info' => 'Informe o mês de referência no formato “mmaaaa”',
+            'format' => ''
         ]
     ];
 
@@ -102,7 +102,7 @@ class E116 extends Element implements ElementInterface
          */
         if (!empty($this->std->num_proc) && (empty($this->std->ind_proc) || empty($this->std->proc))) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se o campo NUM_PROC estiver preenchido, "
-            ."os campos IND_PROC e PROC também devem estar preenchidos.");
+                . "os campos IND_PROC e PROC também devem estar preenchidos." . $this->std->num_proc);
         }
     }
 }

--- a/src/Elements/ICMSIPI/E250.php
+++ b/src/Elements/ICMSIPI/E250.php
@@ -14,8 +14,8 @@ class E250 extends Element implements ElementInterface
 
     protected $parameters = [
         'COD_OR' => [
-            'type'     => 'string',
-            'regex'    => '^.[001|002|006|999]+$',
+            'type' => 'string',
+            'regex' => '^[000|001|002|003|004|005|006|090|999]+$',
             'required' => true,
             'info'     => 'Código da obrigação a recolher, conforme a Tabela 5.4',
             'format'   => ''

--- a/src/Elements/ICMSIPI/E250.php
+++ b/src/Elements/ICMSIPI/E250.php
@@ -101,7 +101,7 @@ class E250 extends Element implements ElementInterface
          * estar preenchidos. Se este campo não estiver preenchido, os campos IND_PROC e PROC não deverão estar
          * preenchidos.
          */
-        if (!empty($this->std->num_proc) && (empty($this->std->ind_proc) || empty($this->std->proc))) {
+        if (!empty($this->std->num_proc) && (($this->std->ind_proc != '0' && empty($this->std->ind_proc)) || empty($this->std->proc))) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se o campo NUM_PROC estiver preenchido, "
                 . "os campos IND_PROC e PROC deverão estar preenchidos." . $this->std->ind_proc);
         }

--- a/src/Elements/ICMSIPI/E250.php
+++ b/src/Elements/ICMSIPI/E250.php
@@ -103,11 +103,11 @@ class E250 extends Element implements ElementInterface
          */
         if (!empty($this->std->num_proc) && (($this->std->ind_proc != '0' && empty($this->std->ind_proc)) || empty($this->std->proc))) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se o campo NUM_PROC estiver preenchido, "
-                . "os campos IND_PROC e PROC deverão estar preenchidos." . $this->std->ind_proc);
+                . "os campos IND_PROC e PROC deverão estar preenchidos.");
         }
         if (empty($this->std->num_proc) && (!empty($this->std->ind_proc) || !empty($this->std->proc))) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se o campo NUM_PROC não estiver preenchido, "
-                . "os campos IND_PROC e PROC não deverão estar preenchidos." . $this->std->ind_proc);
+                . "os campos IND_PROC e PROC não deverão estar preenchidos.");
         }
     }
 }

--- a/src/Elements/ICMSIPI/E250.php
+++ b/src/Elements/ICMSIPI/E250.php
@@ -17,69 +17,69 @@ class E250 extends Element implements ElementInterface
             'type' => 'string',
             'regex' => '^[000|001|002|003|004|005|006|090|999]+$',
             'required' => true,
-            'info'     => 'Código da obrigação a recolher, conforme a Tabela 5.4',
-            'format'   => ''
+            'info' => 'Código da obrigação a recolher, conforme a Tabela 5.4',
+            'format' => ''
         ],
         'VL_OR' => [
-            'type'     => 'numeric',
-            'regex'    => '^\d+(\.\d*)?|\.\d+$',
+            'type' => 'numeric',
+            'regex' => '^\d+(\.\d*)?|\.\d+$',
             'required' => true,
-            'info'     => 'Valor da obrigação ICMS ST a recolher',
-            'format'   => '15v2'
+            'info' => 'Valor da obrigação ICMS ST a recolher',
+            'format' => '15v2'
         ],
         'DT_VCTO' => [
-            'type'     => 'integer',
-            'regex'    => '^(0[1-9]|[1-2][0-9]|31(?!(?:0[2469]|11))|30(?!02))(0[1-9]|1[0-2])([12]\d{3})$',
+            'type' => 'integer',
+            'regex' => '^(0[1-9]|[1-2][0-9]|31(?!(?:0[2469]|11))|30(?!02))(0[1-9]|1[0-2])([12]\d{3})$',
             'required' => true,
-            'info'     => 'Data de vencimento da obrigação',
-            'format'   => ''
+            'info' => 'Data de vencimento da obrigação',
+            'format' => ''
         ],
         'COD_REC' => [
-            'type'     => 'string',
-            'regex'    => '^.*$',
+            'type' => 'string',
+            'regex' => '^.*$',
             'required' => true,
-            'info'     => 'Código de receita referente à obrigação, próprio da unidade da '
-            .'federação do contribuinte substituído.',
-            'format'   => ''
+            'info' => 'Código de receita referente à obrigação, próprio da unidade da '
+                . 'federação do contribuinte substituído.',
+            'format' => ''
         ],
         'NUM_PROC' => [
-            'type'     => 'string',
-            'regex'    => '^.{1,15}$',
+            'type' => 'string',
+            'regex' => '^.{1,15}$',
             'required' => false,
-            'info'     => 'Número do processo ou auto de infração ao qual a obrigação está vinculada, se houver',
-            'format'   => ''
+            'info' => 'Número do processo ou auto de infração ao qual a obrigação está vinculada, se houver',
+            'format' => ''
         ],
         'IND_PROC' => [
-            'type'     => 'string',
-            'regex'    => '^[0|1|2|9]$',
+            'type' => 'string',
+            'regex' => '^[0|1|2|9]$',
             'required' => false,
-            'info'     => 'Indicador da origem do processo: '
-            .'0- SEFAZ; '
-            .'1- Justiça Federal; '
-            .'2- Justiça Estadual; '
-            .'9- Outros',
-            'format'   => ''
+            'info' => 'Indicador da origem do processo: '
+                . '0- SEFAZ; '
+                . '1- Justiça Federal; '
+                . '2- Justiça Estadual; '
+                . '9- Outros',
+            'format' => ''
         ],
         'PROC' => [
-            'type'     => 'string',
-            'regex'    => '^.*$',
+            'type' => 'string',
+            'regex' => '^.*$',
             'required' => false,
-            'info'     => 'Descrição resumida do processo que embasou o lançamento',
-            'format'   => ''
+            'info' => 'Descrição resumida do processo que embasou o lançamento',
+            'format' => ''
         ],
         'TXT_COMPL' => [
-            'type'     => 'string',
-            'regex'    => '^.*$',
+            'type' => 'string',
+            'regex' => '^.*$',
             'required' => false,
-            'info'     => 'Descrição complementar das obrigações a recolher',
-            'format'   => ''
+            'info' => 'Descrição complementar das obrigações a recolher',
+            'format' => ''
         ],
         'MES_REF' => [
-            'type'     => 'integer',
-            'regex'    => '^((?!(13^))|30(?!02))(0[1-9]|1[0-2])([12]\d{3})$',
+            'type' => 'integer',
+            'regex' => '^((?!(13^))|30(?!02))(0[1-9]|1[0-2])([12]\d{3})$',
             'required' => true,
-            'info'     => 'Informe o mês de referência no formato “mmaaaa”',
-            'format'   => ''
+            'info' => 'Informe o mês de referência no formato “mmaaaa”',
+            'format' => ''
         ]
     ];
 
@@ -103,11 +103,11 @@ class E250 extends Element implements ElementInterface
          */
         if (!empty($this->std->num_proc) && (empty($this->std->ind_proc) || empty($this->std->proc))) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se o campo NUM_PROC estiver preenchido, "
-            ."os campos IND_PROC e PROC deverão estar preenchidos.");
+                . "os campos IND_PROC e PROC deverão estar preenchidos." . $this->std->ind_proc);
         }
         if (empty($this->std->num_proc) && (!empty($this->std->ind_proc) || !empty($this->std->proc))) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se o campo NUM_PROC não estiver preenchido, "
-            ."os campos IND_PROC e PROC não deverão estar preenchidos.");
+                . "os campos IND_PROC e PROC não deverão estar preenchidos." . $this->std->ind_proc);
         }
     }
 }

--- a/src/Elements/ICMSIPI/H005.php
+++ b/src/Elements/ICMSIPI/H005.php
@@ -48,8 +48,8 @@ class H005 extends Element implements ElementInterface
             'format'   => '15v2'
         ],
         'MOT_INV' => [
-            'type'     => 'string',
-            'regex'    => '^(0[1-5]{1})$',
+            'type' => 'string',
+            'regex' => '^(0[1-6]{1})$',
             'required' => true,
             'info'     => 'Informe o motivo do Inventário: '
             . '01 – No final no período; '


### PR DESCRIPTION
[//]: # (jira: "{"IssueId":"23267","UpdatedAt":"2025-07-18T16:43:33.094-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/EWEB-94> - 23984 - Geração do Bloco E Sped Fiscal
> Autor: @DemartiniBruno
> Responsável Teste: @Gasperini21

## Descrição
<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p><b>Solicitação Aceita <span class="error">&#91;Análise&#93;</span></b></p>

<p> <b>HIST001:</b> Geração do Bloco E do Sped Fiscal.</p>
</div></div>

<div class="panel" style="background-color: #deebff;border-width: 1px;"><div class="panelContent" style="background-color: #deebff;">
<p> <b>Histórias do usuário <span class="error">&#91;Product Owner&#93;</span></b> </p>

<p><b>HIST001:</b> n/a</p>
</div></div>

<div class="panel" style="background-color: #fffae6;border-width: 1px;"><div class="panelContent" style="background-color: #fffae6;">
<p> <b>Regras de negócio <span class="error">&#91;Product Owner&#93;</span></b> </p>

<p><b>RN001:</b> Adicionar Geração de Registro do Bloco E</p>

<p>RN002: Ao marcar a opção de Bloco E, deverá automaticamente os registros E001, E100 e E110</p>

<p>RN003: Para registro automáticos, deverá ser validado campos obrigatórios e gerados; caso seja informado manual deverá ser gerado com dados do usuario. </p>

<p>RN004: Para os Registros que não são automaticos, deverão ser gerados somente quando informado algum dado manual. </p>
</div></div>

<div class="panel" style="background-color: #eae6ff;border-width: 1px;"><div class="panelContent" style="background-color: #eae6ff;">
<p><b>Requisitos funcionais ou não funcionais <span class="error">&#91;Product Owner &amp; Dev&#93;</span></b> </p>

<p><b>RF001:</b> Adequar Layout de Geração, conforme projeto UX/UI proposto.</p>

<p><b>RF002</b>: Apresentar em Fiscal &gt; Relatórios &gt; Sped Fiscal &gt; </p>

<ul>
	<li>Bloco E - Apuração de ICMS e IPI
	<ul>
		<li>Quando marcado, deverá gerar os registros &gt; E001, E100 e E110</li>
	</ul>
	</li>
	<li>Quando marcado a opção Bloco E acima, deverá habilitar a opção dos Registro Adciccionais</li>
</ul>




<p><b>RF003: Estrutura do Bloco, por registro:</b></p>

<ul>
	<li><b>E001:</b> Objetivo abrir o Bloco E e indica se há informações sobre apuração do ICMS e do IPI.
	<ul>
		<li><b>Regra de Geração:</b>
		<ul>
			<li>Gerar quando marcado o Bloco E, durante a geração.</li>
			<li>Indicador de Movimento: Padrão = 1</li>
		</ul>
		</li>
		<li>E001|IND_MOV
		<ul>
			<li>Registro|indicador de movimento
			<ul>
				<li>Indicador de movimento: 0- Bloco com dados informados; 1- Bloco sem dados informados.</li>
			</ul>
			</li>
			<li>Exemplo do Registro:
			<ul>
				<li><div class='table-wrap'>
<table class='confluenceTable'><tbody>
<tr>
<td class='confluenceTd'>E001</td>
<td class='confluenceTd'>1</td>
</tr>
</tbody></table>
</div>
</li>
			</ul>
			</li>
		</ul>
		</li>
	</ul>
	</li>
</ul>




<ul>
	<li><b>E100:</b> Objetivo informar o(s) período(s) de apuração do ICMS. Os períodos informados devem abranger todo o intervalo da escrituração fiscal, sem sobreposição ou omissão de datas ou períodos.
	<ul>
		<li><b>Regra de Geração:</b>
		<ul>
			<li>Geração obrigatória, sempre que gerado o E001;</li>
		</ul>
		</li>
		<li>E100|DT_INI|DT_FIN
		<ul>
			<li>DT_INI: deverá ser igual ou menor ao valor do camapo DT_FIN do Registro 0000</li>
			<li>DT_FIN deverá ser igual ou maior ao valor do campo  DT_INI do Registro 0000</li>
		</ul>
		</li>
		<li>Exemplo do Registro:
		<ul>
			<li>E100|01012025|31012025</li>
		</ul>
		</li>
	</ul>
	</li>
</ul>




<ul>
	<li><b>E110:</b> Objetivo informar os valores relativos à apuração do ICMS referentes às operações próprias.
	<ul>
		<li><b>Regra de Geração:</b>
		<ul>
			<li>Geração somente quando informado algum campo;</li>
			<li>Caso seja informado valores na tela de geração do Sped, deverá ser informado, caso contrário, gerar registro com valores zerados.</li>
		</ul>
		</li>
		<li><div class='table-wrap'>
<table class='confluenceTable'><tbody>
<tr>
<td class='confluenceTd'>E110</td>
<td class='confluenceTd'>VL_TOT_DEBITOS</td>
<td class='confluenceTd'>VL_AJ_DEBITOS</td>
<td class='confluenceTd'>VL_TOT_AJ_DEBITOS</td>
<td class='confluenceTd'>VL_ESTORNOS_CRED</td>
<td class='confluenceTd'>VL_TOT_CREDITOS</td>
<td class='confluenceTd'>VL_AJ_CREDITOS</td>
<td class='confluenceTd'>VL_TOT_AJ_CREDITOS</td>
<td class='confluenceTd'>VL_ESTORNOS_DEB</td>
<td class='confluenceTd'>VL_SLD_APURADO</td>
<td class='confluenceTd'>VL_TOT_DED</td>
<td class='confluenceTd'>VL_ICMS_RECOLHER</td>
<td class='confluenceTd'>VL_SLD_CREDOR_TRANSPORTAR)</td>
<td class='confluenceTd'>DEB_ESP</td>
</tr>
</tbody></table>
</div>

		<ul>
			<li>Todos demais campos: Campo para informação manual - obrigatório pelo menos 1 campo preenchido para geração.</li>
		</ul>
		</li>
		<li>Exemplo do Registro:
		<ul>
			<li><div class='table-wrap'>
<table class='confluenceTable'><tbody>
<tr>
<td class='confluenceTd'>E110</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
<td class='confluenceTd'>0,00</td>
</tr>
</tbody></table>
</div>
</li>
		</ul>
		</li>
	</ul>
	</li>
</ul>




<ul>
	<li><b>E115:</b> Objetivo de informar os valores declaratórios relativos ao ICMS
	<ul>
		<li><b>Regra de Geração:</b>
		<ul>
			<li>Caso seja informado valores na tela de geração do Sped, deverá ser informado, caso contrário, não gerar.</li>
			<li>Poderá ser gerado mais de um registro para o mesmo.</li>
		</ul>
		</li>
		<li>E115|COD_INF_ADIC|VL_INF_ADIC|DESCR_COMPL_AJ
		<ul>
			<li>Código da informação adicional: Campo para informação manual - Obrigatório para geração</li>
			<li>Valor referente à informação adicional: Campo para informação manual - Obrigatório para geração</li>
			<li>Descrição complementar do ajuste: Campo para informação manual - Não Obrigatório para geração</li>
		</ul>
		</li>
		<li>Exemplo do Registro:
		<ul>
			<li><div class='table-wrap'>
<table class='confluenceTable'><tbody>
<tr>
<td class='confluenceTd'>E115</td>
<td class='confluenceTd'>SC000001</td>
<td class='confluenceTd'>152</td>
</tr>
</tbody></table>
</div>
</li>
		</ul>
		</li>
	</ul>
	</li>
</ul>




<ul>
	<li><b><em>E116:</em></b> Objetivo de discriminar os pagamentos realizados ou a realizar, referentes à apuração do ICMS
	<ul>
		<li><b>Regra de Geração:</b>
		<ul>
			<li>Gerar somente caso tenha algum campo informado manualmente.</li>
			<li>Código da obrigação a recolher: Obrigatório para geração</li>
			<li>Poderá ser gerado mais de um registro para o mesmo.</li>
		</ul>
		</li>
		<li>E116|COD_OR|VL_OR|DT_VCTO|COD_REC|NUM_PROC|IND_PROC|PROC|TXT_COMPL|MES_REF
		<ul>
			<li>Código da obrigação a recolher: Campo para seleção - Obrigatório para geração → <span class="nobr"><a href="/rest/api/3/attachment/content/31201" title="tb19.txt attached to EWEB-94" data-attachment-type="file" data-attachment-name="tb19.txt" data-media-services-type="file" data-media-services-id="9cb3411a-7fa8-4d45-ab4f-f8cc1aaee313" rel="noreferrer">tb19.txt<sup><img class="rendericon" src="/images/icons/link_attachment_7.gif" height="7" width="7" align="absmiddle" alt="" border="0"/></sup></a></span></li>
			<li>Valor da obrigação a recolher: Campo para informação manual - Obrigatório para geração</li>
			<li>Data de vencimento da obrigação: Campo para informação manual - Obrigatório para geração</li>
			<li>Código de receita: Campo para informação manual - Obrigatório para geração</li>
			<li>Número do processo: Campo para informação manual - Não obrigatório para geração</li>
			<li>Indicador da origem do processo: Campo para informação manual - Não obrigatório para geração</li>
			<li>Descrição resumida do processo: Campo para informação manual - Não obrigatório para geração</li>
			<li>Descrição complementar: Campo para informação manual - Não obrigatório para geração</li>
			<li>Mês de referência: Campo para informação manual - Obrigatório para geração</li>
		</ul>
		</li>
		<li>Exemplo do Registro:
		<ul>
			<li>E116|1234|1500.00|15062025|100099|123456789012345|1|Auto de infração referente à diferença de ICMS apurada em fiscalização|Recolhimento complementar devido à fiscalização ocorrida em maio|052025|</li>
		</ul>
		</li>
	</ul>
	</li>
</ul>




<ul>
	<li><b>E200:</b> Objetivo informar o(s) período(s) de apuração do ICMS – Substituição Tributária para cada UF onde o informante seja inscrito como substituto tributário
	<ul>
		<li><b>Regra de Geração:</b>
		<ul>
			<li>Caso seja informado valores na tela de geração do Sped, deverá ser informado, caso contrário, não gerar.</li>
			<li>Poderá ser gerado mais de um registro.</li>
		</ul>
		</li>
		<li>E200|UF|DT_INI|DT_FIN
		<ul>
			<li>UF: Campo para informação manual - Obrigatório para geração</li>
			<li>Data Inicial: Campo para informação manual - Obrigatório para geração</li>
			<li>Data Final: Campo para informação manual - Obrigatório para geração</li>
		</ul>
		</li>
		<li>Exemplo do Registro:
		<ul>
			<li>E200|SP|01062025|30062025|</li>
		</ul>
		</li>
	</ul>
	</li>
</ul>




<ul>
	<li><b>E210:</b> Objetivo informar valores relativos à apuração do ICMS de substituição tributária
	<ul>
		<li><b>Regra de Geração:</b>
		<ul>
			<li>Somente deverá gerar um registro</li>
			<li>Obrigatório IND_MOV_ST ser informado</li>
			<li>Campos não obrigatórios, devem ser gerado, com 0.00 quando não informados</li>
		</ul>
		</li>
		<li>E210|IND_MOV_ST|VL_SLD_CRED_ANT_ST|VL_DEVOL_ST|VL_RESSARC_ST|VL_OUT_CRED_ST|VL_AJ_CREDITOS_ST|VL_RETENÇAO_ST|VL_OUT_DEB_ST|VL_AJ_DEBITOS_ST|VL_SLD_DEV_ANT_ST|VL_DEDUÇÕES_ST|VL_ICMS_RECOL_ST|L_SLD_CRED_ST_TRANS PORTAR|DEB_ESP_ST
		<ul>
			<li>Indicador de movimento: 0 - Sem operações com ST | 1 - Com operações de ST: Campo para informação manual - Obrigatório para geração</li>
			<li>Valor do "Saldo credor de período anterior – Substituição Tributária": Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor total do ICMS ST de devolução de mercadorias: Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor total do ICMS ST de ressarcimentos: Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor total de Ajustes "Outros créditos ST" e “Estorno de débitos ST”: Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor total dos ajustes a crédito de ICMS ST, provenientes de ajustes do documento fiscal: Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor Total do ICMS retido por Substituição Tributária: Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor Total dos ajustes "Outros débitos ST" " e “Estorno de créditos ST”: Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor total dos ajustes a débito de ICMS ST, provenientes de ajustes do documento fiscal: Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor total de Saldo devedor antes das deduções: Campo para informação manual - Não obrigatório para geração</li>
			<li>Valor total dos ajustes "Deduções ST": Campo para informação manual - Não obrigatório para geração</li>
			<li>Imposto a recolher ST:  Campo para informação manual - Não obrigatório para geração</li>
			<li>Saldo credor de ST a transportar:  Campo para informação manual - Não obrigatório para geração</li>
			<li>Valores recolhidos ou a recolher, extra-apuração:  Campo para informação manual - Não obrigatório para geração</li>
		</ul>
		</li>
		<li>Exemplo do Registro:
		<ul>
			<li>E210|1|5000.00|0.00|0.00|500.00|200.00|100.00|0.00|50.00|6550.00|150.00|6400.00|0.00|</li>
		</ul>
		</li>
	</ul>
	</li>
</ul>




<ul>
	<li><b>E250:</b> Objetivo discriminar os pagamentos realizados ou a realizar, referentes à apuração do ICMS devido por Substituição Tributária do período, por UF
	<ul>
		<li><b>Regra de Geração:</b>
		<ul>
			<li>Gerar somente quando informado manualmente algum campo</li>
			<li>Somente deverá gerar um registro</li>
			<li>MES_REF*: Gerar automaticamente mês de referencia do Registro 0000</li>
		</ul>
		</li>
		<li>E250|COD_OR|VL_OR|DT_VCTO|COD_REC|NUM_PROC|IND_PROC|PROC|TXT_COMPL|MES_REF*
		<ul>
			<li>Código da obrigação a recolher: Campo para seleção - Obrigatório para geração → <span class="nobr"><a href="/rest/api/3/attachment/content/31201" title="tb19.txt attached to EWEB-94" data-attachment-type="file" data-attachment-name="tb19.txt" data-media-services-type="file" data-media-services-id="9cb3411a-7fa8-4d45-ab4f-f8cc1aaee313" rel="noreferrer">tb19.txt<sup><img class="rendericon" src="/images/icons/link_attachment_7.gif" height="7" width="7" align="absmiddle" alt="" border="0"/></sup></a></span></li>
			<li>Valor da obrigação ICMS ST a recolher: Campo para informação manual - Obrigatório para geração</li>
			<li>Data de vencimento: Campo para informação manual - Obrigatório para geração</li>
			<li>Código de receita: Campo para informação manual - Obrigatório para geração</li>
			<li>Número do processo: Campo para informação manual - Obrigatório para geração</li>
			<li>Número do processo ou auto de infração: Campo para informação manual - Não obrigatório para geração</li>
			<li>Indicador da origem: 0 - SEFAZ; 1- Justiça Federal; 2- Justiça Estadual; 9- Outros (Campo para informação manual - Não obrigatório para geração)</li>
			<li>Descrição resumida do processo que embasou o lançamento: Campo para informação manual - Não obrigatório para geração</li>
			<li>Descrição complementar das obrigações a recolher: Campo para informação manual - Não obrigatório para geração</li>
		</ul>
		</li>
		<li>Exemplo do Registro:
		<ul>
			<li>E250|001|3200.00|20072025|105001|765432198765432|1|Auto de infração por falta de retenção de ICMS ST|Recolhimento referente a mercadorias adquiridas sem substituição|072025|</li>
		</ul>
		</li>
	</ul>
	</li>
</ul>
</div></div>

<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p> <b>Critérios de aceitação <span class="error">&#91;Product Owner &amp; Tester&#93;</span></b> </p>

<p>O projeto será considerado aprovado pelo time de qualidade quando forem atendidos os seguintes critérios de aceitação:  </p>

<ul>
	<li>Layout de tela conforme proposto por UX/UI</li>
	<li>Registros gerados de acordo com RF.</li>
	<li>Validado no PVA arquivo gerado</li>
	<li>Preencher de forma clara nas Notas de Qualidade e Orientação, para documentação do Suporte Técnico</li>
</ul>
</div></div>

## Nota técnica do desenvolvedor
<p>Pode afetar</p>

<ul>
	<li>Geração do registro C170</li>
	<li>Componentes que utilizam o componente global ZMultipleRadioInput.vue
	<ul>
		<li>Pelo que vi no código só os relatórios utilizam, então testar os relatórios diferentes do sped</li>
		<li>Foi adicionado uma prop nova para adicionar um style inline para as opções</li>
	</ul>
	</li>
</ul>
